### PR TITLE
Make the recipe compatible with Drupal 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "drupal/admin_toolbar": "^3.4",
-        "drupal/coffee": "^1.4",
+        "drupal/coffee": "^1.4 || ^2.0",
         "drupal/decoupled_preview_iframe": "^1.0",
         "drupal/dynamic_entity_reference": "^3.2",
         "drupal/field_group": "^3.4",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "drupal/password_policy": "^4.0",
         "drupal/pathauto": "^1.12",
         "drupal/redirect": "^1.9",
-        "drupal/simple_oauth": "^5.2",
+        "drupal/simple_oauth": "^5.2 || ^6.0",
         "drupal/subpathauto": "^1.3",
         "drupal/view_unpublished": "^1.2",
         "drupal/viewfield": "^3.0@beta",


### PR DESCRIPTION
This resolved composer constraints, but 'visual_editor_paragraphs' in the recipe is still not D11 compatible, probably due to visual_editor_paragraphs having strict `11` constraint instead of a range or semver style
```
core_version_requirement: ^9 || ^10 || 11
```
Source: https://git.drupalcode.org/project/visual_editor/-/blob/1.0.11/modules/visual_editor_paragraphs/visual_editor_paragraphs.info.yml#L4